### PR TITLE
Remove moduleId from components

### DIFF
--- a/src/app/+connections/create/create.component.ts
+++ b/src/app/+connections/create/create.component.ts
@@ -17,7 +17,6 @@ let log = Logger.get('+connections/create');
 const STATE_KEY = 'connection-create-state';
 
 @Component({
-  moduleId: module.id,
   selector: 'connections-create',
   styles: [ require('./create.scss') ],
   templateUrl: './create.html',
@@ -106,7 +105,7 @@ export class Create implements OnInit, OnDestroy {
     return _.map(this.tags.split(','), (tag) => tag.trim());
   }
 
- 
+
   // State management
   persistState() {
     this.state.set(STATE_KEY, {
@@ -125,7 +124,7 @@ export class Create implements OnInit, OnDestroy {
   clearState() {
     this.state.clear(STATE_KEY, true);
   }
-  
+
   enableForm() {
     if (!this.enabledFields) {
       return false;

--- a/src/app/+connections/detail/detail.component.ts
+++ b/src/app/+connections/detail/detail.component.ts
@@ -10,7 +10,6 @@ import { Logger } from '../../common/service/log';
 let log = Logger.get('+connections/detail');
 
 @Component({
-  moduleId: module.id,
   selector: 'connections-detail',
   encapsulation: ViewEncapsulation.None,
   styleUrls: [ 'detail.scss' ],

--- a/src/app/+connections/edit/edit.component.ts
+++ b/src/app/+connections/edit/edit.component.ts
@@ -9,7 +9,6 @@ import { Logger } from '../../common/service/log';
 var log = Logger.get('+connections/edit');
 
 @Component({
-  moduleId: module.id,
   selector: 'connections-edit',
   styles: [ require('./edit.scss') ],
   templateUrl: './edit.html',

--- a/src/app/+connections/library/library.component.ts
+++ b/src/app/+connections/library/library.component.ts
@@ -11,7 +11,6 @@ import { Router } from '@angular/router';
 let log = Logger.get('+connections/library');
 
 @Component({
-  moduleId: module.id,
   selector: 'connections-library',
   encapsulation: ViewEncapsulation.None,
   styles: [ require('./library.scss') ],

--- a/src/app/+dashboard/dashboard.component.ts
+++ b/src/app/+dashboard/dashboard.component.ts
@@ -12,7 +12,6 @@ import { Logger } from '../common/service/log';
 let log = Logger.get('+connections');
 
 @Component({
-  moduleId: module.id,
   // The selector is what angular internally uses
   // for `document.querySelectorAll(selector)` in our index.html
   selector: 'dashboard',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,6 @@ let log = Logger.get('App');
  * Top Level Component
  */
 @Component({
-    moduleId: module.id,
     selector: 'app',
     encapsulation: ViewEncapsulation.None,
     styles: [ require('../assets/scss/main.scss') ],


### PR DESCRIPTION
This was breaking `npm run build:prod` with error:

    Uncaught TypeError: t.match is not a function

Same error at AngularClass/angular2-webpack-starter#958 with solution at https://github.com/AngularClass/angular2-webpack-starter/issues/958#issuecomment-249502528.

This doesn't seem to cause any problems with dev or production mode, but there may be consequences I'm totally unaware of as an ng2 & webpack n00b. Another support of removing this is in http://stackoverflow.com/questions/37178192/angular2-what-is-the-meanings-of-module-id-in-component#37178813 (lots of upvotes & accepted answer btw) which says:

    If you are using webpack for bundling then you don't need  module.id in decorator. Webpack plugins auto handle (add it)  module.id in final bundle