### PR TITLE
Aesthetic Changes, Undo State Management & Updates to Detail View

### DIFF
--- a/src/app/+connections/component.service.ts
+++ b/src/app/+connections/component.service.ts
@@ -4,8 +4,7 @@ import { Http, Headers, RequestOptions, Response } from '@angular/http';
 // Here were are mostly using observables instead of promises
 import { Observable } from 'rxjs/Observable';
 
-//import * as _ from 'lodash';
-
+import { Globals } from '../app.config';
 import { IComponent } from './component.model';
 //import { IComponentService } from './component.service.interface';
 
@@ -18,11 +17,7 @@ export class ComponentService {
 
   errorMessage: string;
   private allComponents: IComponent[];
-
-  //baseUrl: string;
-  //private componentsUrl = 'app/+components/component.data.json'; // URL to JSON file
-  //private componentsUrl = 'http://localhost:9090';
-  private baseUrl = 'http://localhost:9090/v1';
+  private baseUrl = Globals.apiEndpoint;
 
 
   /**

--- a/src/app/+connections/component.service.ts
+++ b/src/app/+connections/component.service.ts
@@ -66,7 +66,10 @@ export class ComponentService {
    * @return {Observable<Component[]>} - Returns an Observable.
    */
   get(id: number): Observable<IComponent> {
-    return this.getAll().map((components: IComponent[]) => components.find(c => c.id === id));
+    return this._http.get(this.baseUrl + '/components/' + id)
+      .map((response: Response) => <IComponent[]> response.json())
+      .do(data => console.log('Response: ' +  JSON.stringify(data)))
+      .catch(this.handleError);
   };
 
 

--- a/src/app/+connections/component.service.ts
+++ b/src/app/+connections/component.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers, RequestOptions, Response } from '@angular/http';
-
-// Here were are mostly using observables instead of promises
 import { Observable } from 'rxjs/Observable';
 
-import { Globals } from '../app.config';
+import { AppState } from '../app.service';
 import { IComponent } from './component.model';
 //import { IComponentService } from './component.service.interface';
 
@@ -15,16 +13,17 @@ let log = Logger.get('ComponentService');
 @Injectable()
 export class ComponentService {
 
-  errorMessage: string;
-  private allComponents: IComponent[];
-  private baseUrl = Globals.apiEndpoint;
-
+  private baseUrl: string;
+  private error: string;
 
   /**
    * Constructor.
    * @param _http - HTTP
+   * @param _appState -- AppState
    */
-  constructor(private _http: Http) {}
+  constructor(private _http: Http, private _appState: AppState) {
+    this.baseUrl = _appState.state.apiEndpoint;
+  }
 
 
   /**
@@ -58,11 +57,11 @@ export class ComponentService {
    * Gets a single Component by its name.
    * This should actually be by ID instead, and needs to be updated.
    * @param id - ID of the Component
-   * @return {Observable<Component[]>} - Returns an Observable.
+   * @return {Observable<Component>} - Returns an Observable.
    */
   get(id: number): Observable<IComponent> {
     return this._http.get(this.baseUrl + '/components/' + id)
-      .map((response: Response) => <IComponent[]> response.json())
+      .map((response: Response) => <IComponent> response.json())
       .do(data => console.log('Response: ' +  JSON.stringify(data)))
       .catch(this.handleError);
   };

--- a/src/app/+connections/connection.model.ts
+++ b/src/app/+connections/connection.model.ts
@@ -1,23 +1,27 @@
 export class IConnection {
-    id: number;
-    name: string;
-    description: string;
-    type: string;
-    icon: string;
-    createdOn: Date;
-    createdBy: string;
-    modifiedOn: Date;
-    modifiedBy: string;
-    
-    constructor() {
-        this.id = 0;
-        this.name = '';
-        this.description = '';
-        this.type = '';
-        this.icon = '';
-        this.createdOn = new Date();
-        this.createdBy = "";
-        this.modifiedOn = new Date();
-        this.modifiedBy = "";
-    }
+  id: number;
+  configuredProperties: any;
+  createdBy: string;
+  createdOn: Date;
+  description: string;
+  icon: string;
+  modifiedBy: string;
+  modifiedOn: Date;
+  name: string;
+  position: string;
+  type: string;
+
+  constructor() {
+    this.id = 0;
+    this.createdBy = '';
+    this.createdOn = new Date();
+    this.configuredProperties = {};
+    this.description = '';
+    this.icon = '';
+    this.modifiedBy = '';
+    this.modifiedOn = new Date();
+    this.name = '';
+    this.position = '';
+    this.type = '';
+  }
 }

--- a/src/app/+connections/connection.service.ts
+++ b/src/app/+connections/connection.service.ts
@@ -56,12 +56,18 @@ export class ConnectionService implements IConnectionService {
   /**
    * Gets a single Connection by its name.
    * @param id - ID of the Connection
-   * @return {Observable<Connection[]>} - Returns an Observable.
+   * @return {Observable<Connection>} - Returns an Observable.
    */
   get(id: number): Observable<IConnection> {
     return this._http.get(this.baseUrl + '/connections/' + id)
-      .map((response: Response) => <IConnection[]> response.json())
-      .do(data => log.debug('Response: ' +  JSON.stringify(data)))
+      .map((response: Response) => <IConnection> response.json())
+      .do(function(data) {
+        log.debug('Response: ' + JSON.stringify(data));
+
+        if (data.configuredProperties) {
+          log.debug('configuredProperties: ' + JSON.stringify(JSON.parse(data.configuredProperties)));
+        }
+      })
       .catch(this.handleError);
   };
 

--- a/src/app/+connections/connection.service.ts
+++ b/src/app/+connections/connection.service.ts
@@ -1,10 +1,7 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Http, Headers, RequestOptions, Response } from '@angular/http';
 
-// Here were are mostly using observables instead of promises
 import { Observable } from 'rxjs/Observable';
-
-//import * as _ from 'lodash';
 
 import { AppState } from '../app.service';
 import { IConnection } from './connection.model';
@@ -51,7 +48,7 @@ export class ConnectionService implements IConnectionService {
   del(id: number): Observable<void> {
     return this._http.delete(this.baseUrl + '/connections/' + id)
       .map((response: Response) => <IConnection[]>response.json())
-      .do(data => console.log('Response: ' + JSON.stringify(data)))
+      .do(data => log.debug('Response: ' + JSON.stringify(data)))
       .catch(this.handleError);
   };
 
@@ -64,7 +61,7 @@ export class ConnectionService implements IConnectionService {
   get(id: number): Observable<IConnection> {
     return this._http.get(this.baseUrl + '/connections/' + id)
       .map((response: Response) => <IConnection[]> response.json())
-      .do(data => console.log('Response: ' +  JSON.stringify(data)))
+      .do(data => log.debug('Response: ' +  JSON.stringify(data)))
       .catch(this.handleError);
   };
 
@@ -76,7 +73,7 @@ export class ConnectionService implements IConnectionService {
   getAll(): Observable<IConnection[]> {
     return this._http.get(this.baseUrl + '/connections')
       .map((response: Response) => <IConnection[]>response.json())
-      .do(data => console.log('All: ' + JSON.stringify(data)))
+      .do(data => log.debug('All: ' + JSON.stringify(data)))
       .catch(this.handleError);
   }
 
@@ -88,7 +85,7 @@ export class ConnectionService implements IConnectionService {
   getRecent(): Observable<IConnection[]> {
     return this._http.get(this.baseUrl + '/connections')
       .map((response: Response) => <IConnection[]>response.json())
-      .do(data => console.log('All: ' + JSON.stringify(data)))
+      .do(data => log.debug('All: ' + JSON.stringify(data)))
       .catch(this.handleError);
   };
 

--- a/src/app/+connections/connection.service.ts
+++ b/src/app/+connections/connection.service.ts
@@ -17,27 +17,15 @@ let log = Logger.get('ConnectionService');
 export class ConnectionService implements IConnectionService {
 
   errorMessage: string;
-  private allConnections: IConnection[];
-  //baseUrl: string;
-  //private connectionsUrl = 'app/+connections/connection.data.json'; // URL to JSON file
-  //private connectionsUrl = 'http://localhost:9090';
   private baseUrl: string;
-  //private baseUrl = 'http://localhost:8080/v1';
-
 
   /**
    * Constructor.
    * @param _http - HTTP
+   * @param _appState -- AppState
    */
   constructor(private _http: Http, private _appState: AppState) {
-    //baseUrl: string;
-    //private connectionsUrl = 'app/+connections/connection.data.json'; // URL to JSON file
-    //private connectionsUrl = 'http://localhost:9090';
-    //this.baseUrl = Globals.apiEndpoint;
-
     this.baseUrl = _appState.state.apiEndpoint;
-
-    console.log('baseUrl: ' + this.baseUrl);
   }
 
 
@@ -70,12 +58,14 @@ export class ConnectionService implements IConnectionService {
 
   /**
    * Gets a single Connection by its name.
-   * This should actually be by ID instead, and needs to be updated.
    * @param id - ID of the Connection
    * @return {Observable<Connection[]>} - Returns an Observable.
    */
   get(id: number): Observable<IConnection> {
-    return this.getAll().map((connections: IConnection[]) => connections.find(c => c.id === id));
+    return this._http.get(this.baseUrl + '/connections/' + id)
+      .map((response: Response) => <IConnection[]> response.json())
+      .do(data => console.log('Response: ' +  JSON.stringify(data)))
+      .catch(this.handleError);
   };
 
 
@@ -117,7 +107,7 @@ export class ConnectionService implements IConnectionService {
 
 
   private extractData(res: Response) {
-    console.log('Response: ' + JSON.stringify(res));
+    log.debug('Response: ' + JSON.stringify(res));
 
     let body = res.json();
     return body.data || {};

--- a/src/app/+connections/create/create.component.ts
+++ b/src/app/+connections/create/create.component.ts
@@ -62,6 +62,9 @@ export class Create implements OnInit, OnDestroy {
   ngOnInit() {
     log.debug('hello `Connections: Create` component');
 
+    /*
+    this.clearState();
+
     const settings = this._state.get(STATE_KEY);
 
     if (settings) {
@@ -75,6 +78,7 @@ export class Create implements OnInit, OnDestroy {
       this.enabledFields = settings.enabledFields || [];
       this.currentStep = settings.currentStep || 1;
     }
+    */
 
     this._componentService.getAll()
       .subscribe(components => this.components = components,
@@ -102,6 +106,9 @@ export class Create implements OnInit, OnDestroy {
   }
 
   getTags() {
+    if(this.tags) {
+      return;
+    }
     return _.map(this.tags.split(','), (tag) => tag.trim());
   }
 
@@ -137,24 +144,24 @@ export class Create implements OnInit, OnDestroy {
   // Steps
   goToStep1() {
     this.currentStep = 1;
-    this.persistState();
+    //this.persistState();
   }
 
   goToStep2() {
     this.currentStep = 2;
-    this.persistState();
+    //this.persistState();
   }
 
   goToStep3() {
     this.currentStep = 3;
-    this.persistState();
+    //this.persistState();
   }
 
   toggleForm() {
     this.showForm = false;
     setTimeout(() => {
       this.showForm = true;
-      this.persistState();
+      //this.persistState();
     }, 5);
   }
 
@@ -208,7 +215,7 @@ export class Create implements OnInit, OnDestroy {
       this.availableFields.push(property);
     });
 
-    this.persistState();
+    //this.persistState();
   }
 
   goBack(currentStep: number, $event: any): void {
@@ -217,11 +224,11 @@ export class Create implements OnInit, OnDestroy {
     currentStep = this.currentStep--;
 
     //log.debug('this.currentStep: ' + this.currentStep);
-    this.persistState();
+    //this.persistState();
   }
 
   cancelCreate(): void {
-    this.clearState();
+    //this.clearState();
     this._router.navigate([ '/connections' ]);
   }
 
@@ -231,7 +238,7 @@ export class Create implements OnInit, OnDestroy {
     currentStep = this.currentStep++;
 
     //log.debug('this.currentStep: ' + this.currentStep);
-    this.persistState();
+    //this.persistState();
   }
 
   createConnection() {
@@ -244,7 +251,7 @@ export class Create implements OnInit, OnDestroy {
     
     // TODO need a 'deploying' page state while this executes
     this._connectionService.create(connection).subscribe((resp) => {
-      this.clearState();
+      //this.clearState();
 
       // Add Toast notification here
 

--- a/src/app/+connections/create/create.component.ts
+++ b/src/app/+connections/create/create.component.ts
@@ -36,13 +36,9 @@ export class Create implements OnInit, OnDestroy {
   tags: string;
   defaults = {};
 
-  //orderByArray: ['name', 'type'];
-
-  //@Input() connections: IConnection[];
   connections: IConnection[];
   connection: IConnection;
 
-  //@Input() components: IComponent[];
   components: IComponent[];
   selectedComponent: IComponent;
   availableFields = [];
@@ -67,6 +63,7 @@ export class Create implements OnInit, OnDestroy {
     log.debug('hello `Connections: Create` component');
 
     const settings = this._state.get(STATE_KEY);
+
     if (settings) {
       this.name = settings.name;
       this.description = settings.description;
@@ -132,6 +129,7 @@ export class Create implements OnInit, OnDestroy {
     if (!this.enabledFields) {
       return false;
     }
+
     return this.showForm;
   }
 
@@ -170,6 +168,7 @@ export class Create implements OnInit, OnDestroy {
 
   removeField(field) {
     _.remove(this.enabledFields, (f) => f.id == field.id);
+
     this.toggleForm();
   }
 
@@ -184,12 +183,14 @@ export class Create implements OnInit, OnDestroy {
 
   moveUp(field) {
     let index = _.indexOf(this.enabledFields, field);
+
     this.move(index, index - 1);
     this.toggleForm();
   }
 
   moveDown(field) {
     let index = _.indexOf(this.enabledFields, field);
+
     this.move(index, index + 1);
     this.toggleForm();
   }
@@ -199,20 +200,23 @@ export class Create implements OnInit, OnDestroy {
     this.availableFields.length = 0;
     this.enabledFields.length = 0;
     this.defaults = {};
+
     const properties = JSON.parse(component.properties);
+
     _.forOwn(properties, (property, key) => {
       property.id = key;
       this.availableFields.push(property);
     });
+
     this.persistState();
   }
 
   goBack(currentStep: number, $event: any): void {
-    console.log('currentStep: ' + currentStep);
+    //log.debug('currentStep: ' + currentStep);
 
     currentStep = this.currentStep--;
 
-    console.log('this.currentStep: ' + this.currentStep);
+    //log.debug('this.currentStep: ' + this.currentStep);
     this.persistState();
   }
 
@@ -222,11 +226,11 @@ export class Create implements OnInit, OnDestroy {
   }
 
   nextStep(currentStep: number, $event: any): void {
-    console.log('currentStep: ' + currentStep);
+    //log.debug('currentStep: ' + currentStep);
 
     currentStep = this.currentStep++;
 
-    console.log('this.currentStep: ' + this.currentStep);
+    //log.debug('this.currentStep: ' + this.currentStep);
     this.persistState();
   }
 
@@ -236,13 +240,17 @@ export class Create implements OnInit, OnDestroy {
       description: this.description,
       icon: this.selectedComponent.icon,
       configuredProperties: JSON.stringify(this.enabledFields)
-    }
+    };
+    
     // TODO need a 'deploying' page state while this executes
     this._connectionService.create(connection).subscribe((resp) => {
       this.clearState();
+
+      // Add Toast notification here
+
       this._router.navigate([ '/connections' ]);
     }, (error) => {
-      console.log("Failed to create connection: ", error);
+      console.log('Failed to create connection: ', error);
     });
   }
 

--- a/src/app/+connections/create/create.component.ts
+++ b/src/app/+connections/create/create.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router'
 
-import { AppState } from '../../app.service.ts';
+import { AppState } from '../../app.service';
 
 // Components
 import { IComponent } from '../component.model';
@@ -55,16 +55,18 @@ export class Create implements OnInit, OnDestroy {
    * @param _componentService - ComponentService
    * @param _connectionService - ConnectionService
    * @param _router - Router
+   * @param _state - AppState
    */
   constructor(private _componentService: ComponentService,
               private _connectionService: ConnectionService,
               private _router: Router,
-              private state:AppState) {}
+              private _state: AppState) {
+  }
 
   ngOnInit() {
     log.debug('hello `Connections: Create` component');
 
-    const settings = this.state.get(STATE_KEY);
+    const settings = this._state.get(STATE_KEY);
     if (settings) {
       this.name = settings.name;
       this.description = settings.description;
@@ -82,7 +84,8 @@ export class Create implements OnInit, OnDestroy {
         error => this.errorMessage = <any>error);
   }
 
-  ngOnDestroy() {}
+  ngOnDestroy() {
+  }
 
   // Components
   getComponents() {
@@ -108,7 +111,7 @@ export class Create implements OnInit, OnDestroy {
 
   // State management
   persistState() {
-    this.state.set(STATE_KEY, {
+    this._state.set(STATE_KEY, {
       name: this.name,
       description: this.description,
       tags: this.tags,
@@ -122,7 +125,7 @@ export class Create implements OnInit, OnDestroy {
   }
 
   clearState() {
-    this.state.clear(STATE_KEY, true);
+    this._state.clear(STATE_KEY, true);
   }
 
   enableForm() {
@@ -164,6 +167,7 @@ export class Create implements OnInit, OnDestroy {
       this.showValidationMessage = true;
     }, 1000);
   }
+
   removeField(field) {
     _.remove(this.enabledFields, (f) => f.id == field.id);
     this.toggleForm();
@@ -175,7 +179,7 @@ export class Create implements OnInit, OnDestroy {
   }
 
   move(from, to) {
-    this.enabledFields.splice(to, 0, this.enabledFields.splice(from, 1)[0]);
+    this.enabledFields.splice(to, 0, this.enabledFields.splice(from, 1)[ 0 ]);
   }
 
   moveUp(field) {
@@ -214,7 +218,7 @@ export class Create implements OnInit, OnDestroy {
 
   cancelCreate(): void {
     this.clearState();
-    this._router.navigate(['/connections']);
+    this._router.navigate([ '/connections' ]);
   }
 
   nextStep(currentStep: number, $event: any): void {
@@ -227,7 +231,7 @@ export class Create implements OnInit, OnDestroy {
   }
 
   createConnection() {
-    let connection:any = {
+    let connection: any = {
       name: this.name,
       description: this.description,
       icon: this.selectedComponent.icon,
@@ -236,7 +240,7 @@ export class Create implements OnInit, OnDestroy {
     // TODO need a 'deploying' page state while this executes
     this._connectionService.create(connection).subscribe((resp) => {
       this.clearState();
-      this._router.navigate(['/connections']);
+      this._router.navigate([ '/connections' ]);
     }, (error) => {
       console.log("Failed to create connection: ", error);
     });

--- a/src/app/+connections/create/create.component.ts
+++ b/src/app/+connections/create/create.component.ts
@@ -107,9 +107,10 @@ export class Create implements OnInit, OnDestroy {
 
   getTags() {
     if(this.tags) {
+      return _.map(this.tags.split(','), (tag) => tag.trim());
+    } else {
       return;
     }
-    return _.map(this.tags.split(','), (tag) => tag.trim());
   }
 
 

--- a/src/app/+connections/create/create.html
+++ b/src/app/+connections/create/create.html
@@ -1,314 +1,347 @@
 <div class="connections create">
-
-    <!-- Toolbar -->
-    <div class="toolbar">
-
-        <!-- Toolbar: Breadcrumbs -->
-        <div class="row toolbar-pf breadcrumbs">
-            <div class="col-sm-12">
-                <ol class="breadcrumb">
-                    <li><a [routerLink]=" ['/home'] ">Home</a></li>
-                    <li><a [routerLink]=" ['/connections'] ">Connections</a></li>
-                    <li class="active"><strong>Create Connection</strong></li>
-                </ol>
-            </div>
-        </div>
-
-
+  
+  <!-- Toolbar -->
+  <div class="toolbar">
+    
+    <!-- Toolbar: Breadcrumbs -->
+    <div class="row toolbar-pf breadcrumbs">
+      <div class="col-sm-12">
+        <ol class="breadcrumb">
+          <li><a [routerLink]=" ['/home'] ">Home</a></li>
+          <li><a [routerLink]=" ['/connections'] ">Connections</a></li>
+          <li class="active"><strong>Create Connection</strong></li>
+        </ol>
+      </div>
     </div>
-
-    <div class="wizard-pf">
-
-        <div class="wizard-pf-body clearfix">
-
-            <!-- Wizard Progress Bar-->
-            <div class="wizard-pf-steps"><!-- hidden -->
-                <ul class="wizard-pf-steps-indicator">
-                  <li class="wizard-pf-step" [class.active]="currentStep === 1"
-                        data-tabgroup="1">
-                        <a><span class="wizard-pf-step-number">1</span><span class="wizard-pf-step-title">Define Connection Basics</span></a>
-                    </li>
-                    <li class="wizard-pf-step" [class.active]="currentStep === 2"
-                        data-tabgroup="2">
-                        <a><span class="wizard-pf-step-number">2</span><span class="wizard-pf-step-title">Select and Configure Fields</span></a>
-                    </li>
-                    <li class="wizard-pf-step" [class.active]="currentStep === 3"
-                        data-tabgroup="3">
-                        <a><span class="wizard-pf-step-number">3</span><span class="wizard-pf-step-title">Review</span></a>
-                    </li>
-                </ul>
-            </div>
-
-            <!-- Wizard Content -->
-
-            <div class="wizard-pf-main row">
-                <!-- Loading--
-                <div class="wizard-pf-loading blank-slate-pf">
-                    <div class="spinner spinner-lg blank-slate-pf-icon"></div>
-                    <h3 class="blank-slate-pf-main-action">Loading Wizard</h3>
-                    <p class="blank-slate-pf-secondary-action">Lorem ipsum dolor sit amet, porta at
-                        suspendisse ac, ut wisi vivamus, lorem sociosqu eget nunc amet. </p>
-                </div>
-                -->
-
-
-                <!-- Step 1 -->
-                <div class="row">
-                  <div class="wizard-pf-contents col-xs-6" *ngIf="currentStep === 1">
-                        <form class="form-horizontal">
-                            <!-- replacing id with data-id to pass build errors -->
-                            <div class="form-group required">
-                                <label class="col-sm-4 control-label"
-                                       for="nameInput">Connection Name&nbsp;<span style="color: red">*
+  
+  
+  </div>
+  
+  <div class="wizard-pf">
+    
+    <div class="wizard-pf-body clearfix">
+      
+      <!-- Wizard Progress Bar-->
+      <div class="wizard-pf-steps"><!-- hidden -->
+        <ul class="wizard-pf-steps-indicator">
+          <li class="wizard-pf-step"
+              [class.active]="currentStep === 1"
+              data-tabgroup="1">
+            <a><span class="wizard-pf-step-number">1</span><span class="wizard-pf-step-title">Define Connection Basics</span></a>
+          </li>
+          <li class="wizard-pf-step"
+              [class.active]="currentStep === 2"
+              data-tabgroup="2">
+            <a><span class="wizard-pf-step-number">2</span><span class="wizard-pf-step-title">Select and Configure Fields</span></a>
+          </li>
+          <li class="wizard-pf-step"
+              [class.active]="currentStep === 3"
+              data-tabgroup="3">
+            <a><span class="wizard-pf-step-number">3</span><span class="wizard-pf-step-title">Review</span></a>
+          </li>
+        </ul>
+      </div>
+      
+      <!-- Wizard Content -->
+      
+      <div class="wizard-pf-main row">
+        <!-- Loading--
+        <div class="wizard-pf-loading blank-slate-pf">
+            <div class="spinner spinner-lg blank-slate-pf-icon"></div>
+            <h3 class="blank-slate-pf-main-action">Loading Wizard</h3>
+            <p class="blank-slate-pf-secondary-action">Lorem ipsum dolor sit amet, porta at
+                suspendisse ac, ut wisi vivamus, lorem sociosqu eget nunc amet. </p>
+        </div>
+        -->
+        
+        
+        <!-- Step 1 -->
+        <div class="row">
+          <div class="wizard-pf-contents col-xs-6"
+               *ngIf="currentStep === 1">
+            <form class="form-horizontal">
+              <!-- replacing id with data-id to pass build errors -->
+              <div class="form-group required">
+                <label class="col-sm-4 control-label"
+                       for="nameInput">Connection Name&nbsp;<span style="color: red">*
                             </span></label>
-                                <div class="col-sm-8">
-                                    <input type="text"
-                                           name="nameInput"
-                                           data-id="nameInput"
-                                           [(ngModel)]="name"
-                                           class="form-control">
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label class="col-sm-4 control-label"
-                                       for="descriptionInput">Description&nbsp;<span style="color: red">*</span></label>
-                                <div class="col-sm-8">
+                <div class="col-sm-8">
+                  <input type="text"
+                         name="nameInput"
+                         data-id="nameInput"
+                         [(ngModel)]="name"
+                         class="form-control">
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-4 control-label"
+                       for="descriptionInput">Description&nbsp;<span style="color: red">*</span></label>
+                <div class="col-sm-8">
                                 <textarea data-id="descriptionInput"
                                           name="descriptionInput"
                                           class="form-control"
                                           [(ngModel)]="description"
                                           rows="2"></textarea>
-                                </div>
-                            </div>
-                            <div class="form-group required">
-                                <label class="col-sm-4 control-label"
-                                  for="tagsInput">Tag(s)</label>
-                                <div class="col-sm-8">
-                                    <input type="text"
-                                           name="tagsInput"
-                                           data-id="tagsInput"
-                                           [(ngModel)]="tags"
-                                           class="form-control">
-                                </div>
-                            </div>
-                        </form>
-                    </div>
-
-                <!-- Step 2 -->
-                  <div class="wizard-pf-contents" *ngIf="currentStep === 2">
-                      <div class="row">
-                        <div class="col-md-4">
-                          <div class="row">
-                            <div class="col-md-7">
-                              <h4>Select {{selectedComponent.name}} Fields</h4>
-                            </div>
-                            <div class="col-md-5">
-                              <input type="text" class="form-control" id="filter" placeholder="Find by name..." [(ngModel)]="fieldListFilter">
-                            </div>
-                          </div>
-                          <div class="row">
-                            <div class="col-md-12">
-                              <ul class="list-group">
-                                <li class="list-group-item" *ngFor="let field of availableFields | fieldFilter : fieldListFilter" (click)="addField(field)">
-                                {{field.title}}
-                                <span *ngIf="fieldAvailable(field)" class="action-element pull-right"><i class="fa fa-plus-circle fa-lg"></i></span>
-                                </li>
-                              </ul>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="col-md-8">
-                          <div class="row">
-                            <div class="col-md-10">
-                              <h4>Set up connection form defaults <span class="badge badge-default">{{enabledFields.length}}</span></h4>
-                            </div>
-                            <div class="col-md-2">
-                              <button class="btn btn-primary" [disabled]="!enabledFields.length" (click)="validateInputs()">Validate</button>
-                            </div>
-                          </div>
-                          <div *ngIf="showValidationMessage">
-                            <div class="alert alert-success">
-                              <button type="button" class="close" (click)="showValidationMessage = false">
-                                <span class="pficon pficon-close"></span>
-                              </button>
-                              <span class="pficon pficon-ok"></span>
-                              <strong>Success!</strong> The provided inputs validate successfully.
-                            </div>
-                          </div>
-                          <div *ngIf="!enabledFields.length" class="blank-slate-pf">
-                            <div class="blank-slate-pf-icon">
-                              <span class="fa fa-reply"></span>
-                            </div>
-                            <p>Add fields from the left that users will fill out when using this connection</p>
-                          </div>
-                          <div *ngIf="enableForm()">
-                            <form #f="ngForm">
-                              <div class="row" *ngFor="let field of enabledFields; let i = index" [attr.data-index]="i">
-                                <div class="col-md-10">
-                                  <form-property-field [form]="f.form" [field]="field" [entity]="defaults"></form-property-field>
-                                </div>
-                                <div class="col-md-2" style="whitespace: nowrap">
-                                  <i [style.visible]="i !== 0" class="action-element fa fa-arrow-up fa-lg" (click)="moveUp(field)"></i>
-                                  <i *ngIf="i !== enabledFields.length - 1" class="action-element fa fa-arrow-down fa-lg" (click)="moveDown(field)"></i>
-                                  <i class="action-element fa fa-trash fa-lg" (click)="removeField(field)"></i>
-                                </div>
-                              </div>
-                            </form>
-                          </div>
-                        </div>
+                </div>
+              </div>
+              <div class="form-group required">
+                <label class="col-sm-4 control-label"
+                       for="tagsInput">Tag(s)</label>
+                <div class="col-sm-8">
+                  <input type="text"
+                         name="tagsInput"
+                         data-id="tagsInput"
+                         [(ngModel)]="tags"
+                         class="form-control">
+                </div>
+              </div>
+            </form>
+          </div>
+          
+          <!-- Step 2 -->
+          <div class="wizard-pf-contents"
+               *ngIf="currentStep === 2">
+            <div class="row">
+              <div class="col-md-4">
+                <div class="row">
+                  <div class="col-md-7">
+                    <h4>Select {{selectedComponent.name}} Fields</h4>
+                  </div>
+                  <div class="col-md-5">
+                    <input type="text"
+                           class="form-control"
+                           id="filter"
+                           placeholder="Find by name..."
+                           [(ngModel)]="fieldListFilter">
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-12">
+                    <ul class="list-group">
+                      <li class="list-group-item"
+                          *ngFor="let field of availableFields | fieldFilter : fieldListFilter"
+                          (click)="addField(field)">
+                        {{field.title}} <span *ngIf="fieldAvailable(field)"
+                                              class="action-element pull-right"><i class="fa fa-plus-circle fa-lg"></i></span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div class="col-md-8">
+                <div class="row">
+                  <div class="col-md-10">
+                    <h4>Set up connection form defaults <span class="badge badge-default">{{enabledFields.length}}</span>
+                    </h4>
+                  </div>
+                  <div class="col-md-2">
+                    <button class="btn btn-primary"
+                            [disabled]="!enabledFields.length"
+                            (click)="validateInputs()">Validate
+                    </button>
+                  </div>
+                </div>
+                <div *ngIf="showValidationMessage">
+                  <div class="alert alert-success">
+                    <button type="button"
+                            class="close"
+                            (click)="showValidationMessage = false">
+                      <span class="pficon pficon-close"></span>
+                    </button>
+                    <span class="pficon pficon-ok"></span> <strong>Success!</strong> The provided inputs
+                    validate successfully.
+                  </div>
+                </div>
+                <div *ngIf="!enabledFields.length"
+                     class="blank-slate-pf">
+                  <div class="blank-slate-pf-icon">
+                    <span class="fa fa-reply"></span>
+                  </div>
+                  <p>Add fields from the left that users will fill out when using this connection</p>
+                </div>
+                <div *ngIf="enableForm()">
+                  <form #f="ngForm">
+                    <div class="row"
+                         *ngFor="let field of enabledFields; let i = index"
+                         [attr.data-index]="i">
+                      <div class="col-md-10">
+                        <form-property-field [form]="f.form"
+                                             [field]="field"
+                                             [entity]="defaults"></form-property-field>
+                      </div>
+                      <div class="col-md-2"
+                           style="whitespace: nowrap">
+                        <i [style.visible]="i !== 0"
+                           class="action-element fa fa-arrow-up fa-lg"
+                           (click)="moveUp(field)"></i> <i *ngIf="i !== enabledFields.length - 1"
+                                                           class="action-element fa fa-arrow-down fa-lg"
+                                                           (click)="moveDown(field)"></i>
+                        <i class="action-element fa fa-trash fa-lg"
+                           (click)="removeField(field)"></i>
                       </div>
                     </div>
-
-                <!-- Step 3 -->
-                    <div class="row row-cards-pf" *ngIf="currentStep === 3">
-                      <div class="row">
-                        <div class="col-md-3">
-                          <div class="card">
-                            <div class="card-pf card-pf-view card-pf-view-xs">
-                              <div class="card-pf-body">
-                                <div class="card-pf-heading">
-                                  <h2 class="card-pf-title">
-                                    <span class="fa {{selectedComponent.icon}}"></span>
-                                  </h2>
-                                  <div class="card-title">{{name}}</div>
-                                </div>
-                                <p>{{description}}</p>
-                                <p>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+          <!-- Step 3 -->
+          <div class="row row-cards-pf"
+               *ngIf="currentStep === 3">
+            <div class="row">
+              <div class="col-md-3">
+                <div class="card">
+                  <div class="card-pf card-pf-view card-pf-view-xs">
+                    <div class="card-pf-body">
+                      <div class="card-pf-heading">
+                        <h2 class="card-pf-title">
+                          <span class="fa {{selectedComponent.icon}}"></span>
+                        </h2>
+                        <div class="card-title">{{name}}</div>
+                      </div>
+                      <p>{{description}}</p>
+                      <p>
                                   <span *ngFor="let tag of getTags()">
                                     <span class="label label-primary">{{tag}}</span>
                                   </span>
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-
-                        </div>
-                        <div class="col-md-9">
-                          <h3>Connection Fields</h3>
-                          <form #f="ngForm">
-                            <div class="row" *ngFor="let field of enabledFields">
-                                <form-property-field [form]="f.form" [field]="field" [entity]="defaults"></form-property-field>
-                            </div>
-                          </form>
-                        </div>
-                      </div>
+                      </p>
                     </div>
+                  </div>
                 </div>
-            </div>
-        </div>
-
-
-        <!-- Toolbar: Select Connection Type -->
-        <div class="row toolbar-pf type" *ngIf="currentStep === 1">
-            <div class="col-xs-12">
-                <form class="toolbar-pf-actions">
-                    <div class="form-group toolbar-pf-filter">
-                        <div>
-                            <label class="sr-only"
-                                   for="filter">Select Connection Type&nbsp;</label>
-                            <input type="text"
-                                   class="form-control"
-                                   id="filter"
-                                   [(ngModel)]="listFilter"
-                                   name="name"
-                                   placeholder="Filter By Name...">
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <div class="dropdown btn-group">
-                            <button type="button"
-                                    class="btn btn-default dropdown-toggle"
-                                    data-toggle="dropdown"
-                                    aria-haspopup="true"
-                                    aria-expanded="false">Name <span class="caret"></span>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a>Name</a></li>
-                                <li><a>Type</a></li>
-                            </ul>
-                        </div>
-                        <button class="btn btn-link"
-                                type="button">
-                            <span class="fa fa-sort-alpha-asc"></span>
-                        </button>
-                    </div>
+              
+              </div>
+              <div class="col-md-9">
+                <h3>Connection Fields</h3>
+                <form #f="ngForm">
+                  <div class="row"
+                       *ngFor="let field of enabledFields">
+                    <form-property-field [form]="f.form"
+                                         [field]="field"
+                                         [entity]="defaults"></form-property-field>
+                  </div>
                 </form>
+              </div>
             </div>
+          </div>
         </div>
+      </div>
     </div>
-
-    <!-- List of Components -->
-    <div *ngIf="currentStep === 1">
-        <div class="row row-cards-pf components">
-            <div class="col-xs-12 col-sm-3 col-md-2 card"
-                 *ngFor="let component of components | componentFilter: listFilter">
-                 <div class="card-pf card-pf-view card-pf-view-xs card-pf-view-select card-pf-view-single-select" [class.active]="component === selectedComponent" (click)="selectComponent(component)">
-                    <div class="card-pf-body">
-                        <div class="card-pf-heading">
-                            <h2 class="card-pf-title">
-                                <span class="fa {{ component.icon }}"></span>
-                            </h2>
-                            <div class="card-title">{{ component.name | truncate:'14':'..' }}</div>
-                        </div>
-                        <p>{{ component.description | truncate:limit:trail }}</p>
-                    </div>
-                </div>
+    
+    
+    <!-- Toolbar: Select Connection Type -->
+    <div class="row toolbar-pf type"
+         *ngIf="currentStep === 1">
+      <div class="col-xs-12">
+        <form class="toolbar-pf-actions">
+          <div class="form-group toolbar-pf-filter">
+            <div>
+              <label class="sr-only"
+                     for="filter">Select Connection Type&nbsp;</label> <input type="text"
+                                                                              class="form-control"
+                                                                              id="filter"
+                                                                              [(ngModel)]="listFilter"
+                                                                              name="name"
+                                                                              placeholder="Filter By Name...">
             </div>
-
-            <!-- Cannot access components outside of ngFor
-            <div class="row row-cards-pf noComponents"
-                 *ngIf="components.length <= 0">
-                <p>There are no Components available to create a Connection.</p>
+          </div>
+          <div class="form-group">
+            <div class="dropdown btn-group">
+              <button type="button"
+                      class="btn btn-default dropdown-toggle"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false">Name <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li><a>Name</a></li>
+                <li><a>Type</a></li>
+              </ul>
             </div>
-            -->
-
-            <div class="error"
-                 *ngIf="errorMessage">{{errorMessage}}
+            <button class="btn btn-link"
+                    type="button">
+              <span class="fa fa-sort-alpha-asc"></span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  
+  <!-- List of Components -->
+  <div *ngIf="currentStep === 1">
+    <div class="row row-cards-pf components">
+      <div class="col-xs-12 col-sm-3 col-md-2 card"
+           *ngFor="let component of components | componentFilter: listFilter">
+        <div class="card-pf card-pf-view card-pf-view-xs card-pf-view-select card-pf-view-single-select"
+             [class.active]="component === selectedComponent"
+             (click)="selectComponent(component)">
+          <div class="card-pf-body">
+            <div class="card-pf-heading">
+              <h2 class="card-pf-title">
+                <span class="fa {{ component.icon }}"></span>
+              </h2>
+              <div class="card-title">{{ component.name | truncate:'14':'..' }}</div>
             </div>
+            <p>{{ component.description | truncate:limit:trail }}</p>
+          </div>
         </div>
+      </div>
+      
+      <!-- Cannot access components outside of ngFor
+      <div class="row row-cards-pf noComponents"
+           *ngIf="components.length <= 0">
+          <p>There are no Components available to create a Connection.</p>
+      </div>
+      -->
+      
+      <div class="error"
+           *ngIf="errorMessage">{{errorMessage}}
+      </div>
     </div>
-
-    <script>
-      (function($) {
-        $(document).ready(function() {
-          // Upon clicking the find button, show the find dropdown content
-          $(".btn-find").click(function() {
-            $(".find-pf-dropdown-container").toggle();
-          });
-          // Upon clicking the find close button, hide the find dropdown content
-          $(".btn-find-close").click(function() {
-            $(".find-pf-dropdown-container").hide();
-          });
-
+  </div>
+  
+  <script>
+    (function($) {
+      $(document).ready(function() {
+        // Upon clicking the find button, show the find dropdown content
+        $(".btn-find").click(function() {
+          $(".find-pf-dropdown-container").toggle();
         });
-      })(jQuery);
-    </script>
+        // Upon clicking the find close button, hide the find dropdown content
+        $(".btn-find-close").click(function() {
+          $(".find-pf-dropdown-container").hide();
+        });
 
-
-    <!-- Wizard Footer -->
-    <div class="wizard-pf-footer">
-        <button type="button"
-                (click)="cancelCreate(currentStep, $event)"
-                class="btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss">Cancel
-        </button>
-        <button type="button"
-                class="btn btn-default wizard-pf-back"
-                (click)="goBack(currentStep, $event)">
-            <span class="i fa fa-angle-left"></span> Back
-        </button>
-        <button type="button"
-                *ngIf="currentStep !== 3"
-                class="btn btn-primary wizard-pf-next"
-                (click)="nextStep(currentStep, $event)">
-            Next <span class="i fa fa-angle-right"></span>
-        </button>
-        <button type="button"
-                *ngIf="currentStep === 3"
-                (click)="createConnection()"
-                class="btn btn-primary wizard-pf-finish">
-           Create
-        </button>
-    </div>
+      });
+    })(jQuery);
+  </script>
+  
+  
+  <!-- Wizard Footer -->
+  <div class="wizard-pf-footer">
+    <button type="button"
+            (click)="cancelCreate(currentStep, $event)"
+            class="btn btn-default btn-cancel wizard-pf-cancel wizard-pf-dismiss">Cancel
+    </button>
+    <button type="button"
+            class="btn btn-default wizard-pf-back"
+            (click)="goBack(currentStep, $event)">
+      <span class="i fa fa-angle-left"></span> Back
+    </button>
+    <button type="button"
+            *ngIf="currentStep !== 3"
+            class="btn btn-primary wizard-pf-next"
+            (click)="nextStep(currentStep, $event)">
+      Next <span class="i fa fa-angle-right"></span>
+    </button>
+    <button type="button"
+            *ngIf="currentStep === 3"
+            (click)="createConnection()"
+            class="btn btn-primary wizard-pf-finish">
+      Create
+    </button>
+  </div>
 
 
 </div>

--- a/src/app/+connections/create/create.html
+++ b/src/app/+connections/create/create.html
@@ -27,17 +27,20 @@
           <li class="wizard-pf-step"
               [class.active]="currentStep === 1"
               data-tabgroup="1">
-            <a><span class="wizard-pf-step-number">1</span><span class="wizard-pf-step-title">Define Connection Basics</span></a>
+            <a> <span class="wizard-pf-step-number">1</span> <span class="wizard-pf-step-title">Define Connection Basics</span>
+            </a>
           </li>
           <li class="wizard-pf-step"
               [class.active]="currentStep === 2"
               data-tabgroup="2">
-            <a><span class="wizard-pf-step-number">2</span><span class="wizard-pf-step-title">Select and Configure Fields</span></a>
+            <a> <span class="wizard-pf-step-number">2</span> <span class="wizard-pf-step-title">Select and Configure Fields</span>
+            </a>
           </li>
           <li class="wizard-pf-step"
               [class.active]="currentStep === 3"
               data-tabgroup="3">
-            <a><span class="wizard-pf-step-number">3</span><span class="wizard-pf-step-title">Review</span></a>
+            <a> <span class="wizard-pf-step-number">3</span>
+              <span class="wizard-pf-step-title">Review</span> </a>
           </li>
         </ul>
       </div>
@@ -202,9 +205,9 @@
                       </div>
                       <p>{{description}}</p>
                       <p>
-                                  <span *ngFor="let tag of getTags()">
-                                    <span class="label label-primary">{{tag}}</span>
-                                  </span>
+                        <span *ngFor="let tag of getTags()">
+                          <span class="label label-primary">{{tag}}</span>
+                        </span>
                       </p>
                     </div>
                   </div>

--- a/src/app/+connections/create/create.scss
+++ b/src/app/+connections/create/create.scss
@@ -45,8 +45,13 @@ div.connections.create {
     border-bottom: solid 1px #d1d1d1;
     margin: auto -20px;
     padding: 0;
+
     .form-horizontal .control-label {
       text-align: left;
+    }
+
+    .wizard-pf-main {
+      padding-bottom: 100px;
     }
   }
 

--- a/src/app/+connections/create/create.scss
+++ b/src/app/+connections/create/create.scss
@@ -35,7 +35,7 @@ div.connections.create {
     height: 120px;
 
     .wizard-pf-steps-indicator {
-      max-width: 50%;
+      max-width: 65%;
       margin: 0 auto;
     }
   }

--- a/src/app/+connections/detail/detail.component.ts
+++ b/src/app/+connections/detail/detail.component.ts
@@ -22,8 +22,6 @@ export class Detail implements OnInit, OnDestroy {
   @Output() close = new EventEmitter();
 
   error: any;
-  navigated = false; // true if navigated here
-  isCollapsed = true;
 
   private sub: Subscription;
 

--- a/src/app/+connections/detail/detail.component.ts
+++ b/src/app/+connections/detail/detail.component.ts
@@ -23,6 +23,7 @@ export class Detail implements OnInit, OnDestroy {
 
   error: any;
   navigated = false; // true if navigated here
+  isCollapsed = true;
 
   private sub: Subscription;
 

--- a/src/app/+connections/detail/detail.component.ts
+++ b/src/app/+connections/detail/detail.component.ts
@@ -44,6 +44,8 @@ export class Detail implements OnInit, OnDestroy {
         let id = +params['id'];
         this.getConnection(id);
       });
+
+    log.debug('Connection: ' + JSON.stringify(this.connection));
   }
 
   ngOnDestroy() {

--- a/src/app/+connections/detail/detail.html
+++ b/src/app/+connections/detail/detail.html
@@ -11,7 +11,7 @@
                     <li class="active"><strong>Connection Details</strong></li>
                 </ol>
                 <a href="#"
-                   class="btn btn-info toolbar-pf-action-right">Edit</a>
+                   class="btn btn-primary toolbar-pf-action-right">Edit</a>
             </div>
         </div>
     </div>

--- a/src/app/+connections/detail/detail.html
+++ b/src/app/+connections/detail/detail.html
@@ -15,12 +15,27 @@
     </div>
 
     <!-- Content -->
-    <div class="row row-cards-pf">
-        <div class="col-xs-12">
-            <div class="card-pf card-pf-accented card-pf-aggregate-status">
+    <div class="row row-cards-pf center">
+        <div class="col-xs-4">
+            <div class="card-pf">
                 <h2 class="card-pf-title">
-                    <span class="fa fa-shield"></span><span
-                        class="card-pf-aggregate-status-count">0</span> Ipsum
+                    {{connection.name}}
+                </h2>
+                <div class="card-pf-body">
+                    <div>
+                        <label>ID: </label>{{connection.id}}</div>
+                    <div>
+                        <label>Name: </label>
+                        <input [(ngModel)]="connection.name" placeholder="name" />
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xs-8">
+            <div class="card-pf">
+                <h2 class="card-pf-title">
+                    Connection Fields
                 </h2>
                 <div class="card-pf-body">
                     <p class="card-pf-aggregate-status-notifications">
@@ -34,22 +49,6 @@
                             </a>
                         </span>
                     </p>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-xs-12">
-            <div class="card-pf card-pf-accented card-pf-aggregate-status">
-                <h2 class="card-pf-title">
-                    Connection Fields: {{connection.name}}
-                </h2>
-                <div class="card-pf-body">
-                    <div>
-                        <label>ID: </label>{{connection.id}}</div>
-                    <div>
-                        <label>Name: </label>
-                        <input [(ngModel)]="connection.name" placeholder="name" />
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/+connections/detail/detail.html
+++ b/src/app/+connections/detail/detail.html
@@ -1,4 +1,10 @@
 <div class="connections detail">
+    <ol class="breadcrumb">
+        <li><a href="#">Back to Top Level</a></li>
+        <li><a href="#">Second Level</a></li>
+        <li><a href="#">Third Level</a></li>
+        <li class="active"><strong>Fourth Level:</strong> Detail about fourth level</li>
+    </ol>
     <div *ngIf="connection">
         <h2>{{connection.name}} details!</h2>
         <div>

--- a/src/app/+connections/detail/detail.html
+++ b/src/app/+connections/detail/detail.html
@@ -1,11 +1,22 @@
-<div class="connections detail">
-    <ol class="breadcrumb">
-        <li><a href="#">Back to Top Level</a></li>
-        <li><a href="#">Second Level</a></li>
-        <li><a href="#">Third Level</a></li>
-        <li class="active"><strong>Fourth Level:</strong> Detail about fourth level</li>
-    </ol>
-    <div *ngIf="connection">
+<div class="connections detail" *ngIf="connection">
+    <!-- Toolbar -->
+    <div class="toolbar">
+
+        <!-- Toolbar: Breadcrumbs -->
+        <div class="row toolbar-pf breadcrumbs">
+            <div class="col-sm-12">
+                <ol class="breadcrumb">
+                    <li><a [routerLink]=" ['/home'] ">Home</a></li>
+                    <li><a [routerLink]=" ['/connections'] ">Connections</a></li>
+                    <li class="active"><strong>Connection Details: {{connection.name}}</strong></li>
+                </ol>
+            </div>
+        </div>
+
+
+    </div>
+
+    <div>
         <h2>{{connection.name}} details!</h2>
         <div>
             <label>ID: </label>{{connection.id}}</div>

--- a/src/app/+connections/detail/detail.html
+++ b/src/app/+connections/detail/detail.html
@@ -4,12 +4,14 @@
 
         <!-- Toolbar: Breadcrumbs -->
         <div class="row toolbar-pf breadcrumbs">
-            <div class="col-sm-12">
+            <div class="col-sm-12 toolbar-pf-actions">
                 <ol class="breadcrumb">
                     <li><a [routerLink]=" ['/home'] ">Home</a></li>
                     <li><a [routerLink]=" ['/connections'] ">Connections</a></li>
-                    <li class="active"><strong>Connection Details: {{connection.name}}</strong></li>
+                    <li class="active"><strong>Connection Details</strong></li>
                 </ol>
+                <a href="#"
+                   class="btn btn-info toolbar-pf-action-right">Edit</a>
             </div>
         </div>
     </div>
@@ -18,15 +20,15 @@
     <div class="row row-cards-pf center">
         <div class="col-xs-4">
             <div class="card-pf">
-                <h2 class="card-pf-title">
-                    {{connection.name}}
-                </h2>
                 <div class="card-pf-body">
-                    <div>
-                        <label>ID: </label>{{connection.id}}</div>
-                    <div>
-                        <label>Name: </label>
-                        <input [(ngModel)]="connection.name" placeholder="name" />
+                    <div class="icon"><span class="fa {{connection.icon}}"></span></div>
+                    <div class="name">
+                        <h2 class="card-pf-title">
+                            {{connection.name}}
+                        </h2>
+                    </div>
+                    <div class="description">
+                        {{connection.description}}
                     </div>
                 </div>
             </div>

--- a/src/app/+connections/detail/detail.html
+++ b/src/app/+connections/detail/detail.html
@@ -12,19 +12,46 @@
                 </ol>
             </div>
         </div>
-
-
     </div>
 
-    <div>
-        <h2>{{connection.name}} details!</h2>
-        <div>
-            <label>ID: </label>{{connection.id}}</div>
-        <div>
-            <label>Name: </label>
-            <input [(ngModel)]="connection.name" placeholder="name" />
+    <!-- Content -->
+    <div class="row row-cards-pf">
+        <div class="col-xs-12">
+            <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">
+                    <span class="fa fa-shield"></span><span
+                        class="card-pf-aggregate-status-count">0</span> Ipsum
+                </h2>
+                <div class="card-pf-body">
+                    <p class="card-pf-aggregate-status-notifications">
+                        <span class="card-pf-aggregate-status-notification">
+                            <a href="#"
+                               class="add"
+                               data-toggle="tooltip"
+                               data-placement="top"
+                               title="Add Ipsum">
+                                <span class="pficon pficon-add-circle-o"></span>
+                            </a>
+                        </span>
+                    </p>
+                </div>
+            </div>
         </div>
-        <button (click)="goBack()">Back</button>
-        <button (click)="save()">Save</button>
+
+        <div class="col-xs-12">
+            <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">
+                    Connection Fields: {{connection.name}}
+                </h2>
+                <div class="card-pf-body">
+                    <div>
+                        <label>ID: </label>{{connection.id}}</div>
+                    <div>
+                        <label>Name: </label>
+                        <input [(ngModel)]="connection.name" placeholder="name" />
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/app/+connections/detail/detail.scss
+++ b/src/app/+connections/detail/detail.scss
@@ -1,1 +1,6 @@
-div.connections.detail {}
+div.connections.detail {
+  .row-cards-pf {
+    padding: 35px 20px;
+    text-align: left;
+  }
+}

--- a/src/app/+connections/detail/detail.scss
+++ b/src/app/+connections/detail/detail.scss
@@ -1,4 +1,8 @@
 div.connections.detail {
+  .toolbar-pf-action-right {
+    margin-top: -30px;
+  }
+
   .row-cards-pf {
     padding: 35px 20px;
     text-align: left;

--- a/src/app/+connections/library/library.component.ts
+++ b/src/app/+connections/library/library.component.ts
@@ -43,7 +43,6 @@ export class Library implements OnInit {
   ngOnInit(): void {
     log.debug('hello `Connections: Library` component');
 
-    //this.getConnections();
     this._connectionService.getAll()
       .subscribe(connections => this.connections = connections,
         error => this.errorMessage = <any>error);
@@ -61,7 +60,7 @@ export class Library implements OnInit {
   }
 
   editConnection(connection: IConnection, $event: any): void {
-    console.log('Connection: ', connection);
+    //log.debug('Connection: ', connection);
 
     let link = [ 'connections', 'edit', connection.name.toLowerCase() ];
 
@@ -72,22 +71,18 @@ export class Library implements OnInit {
     this._router.navigate(['/dashboard']);
   }
 
-  getConnections() {
-    this._connectionService.getAll();
-  }
-
   gotoDetail(connection: IConnection, $event: any): void {
-    console.log('$event: ', $event);
+    //log.debug('$event: ', $event);
 
     let className = _.get($event, 'target.className');
 
-    console.log('Class name: ', className);
+    //log.debug('Class name: ', className);
 
     if ($event && $event.target && $event.target.className.indexOf('dropdown-toggle') !== -1) {
       return;
     }
 
-    console.log('Connection: ', connection);
+    log.debug('Connection: ', connection);
 
     //let link = [ 'connections', 'detail', connection.name.toLowerCase() ];
     let link = [ 'connections', 'detail', connection.id ];

--- a/src/app/+connections/library/library.html
+++ b/src/app/+connections/library/library.html
@@ -1,135 +1,138 @@
 <div class="connections library">
-
-    <!-- Toolbar -->
-
-    <div class="row toolbar-pf">
-        <div class="col-sm-12">
-            <div class="toolbar-pf-actions">
-
-                <!-- Toolbar: Search -->
-
-                <div class="form-group toolbar-pf-filter search">
-                    <label class="sr-only">Name</label>
-                    <div class="input-group">
-                        <div class="input-group-btn">
-                            <button type="button"
-                                    class="btn btn-default dropdown-toggle"
-                                    data-toggle="dropdown"
-                                    aria-haspopup="true"
-                                    aria-expanded="false">Name <span class="caret"></span>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li><a href="#">Name</a></li>
-                                <li><a href="#">Type</a></li>
-                            </ul>
-                        </div>
-                        <input type="text"
-                               class="form-control"
-                               placeholder="Filter By Name..."
-                               autocomplete="off"
-                               [(ngModel)]="listFilter"
-                               id="filterInput">
-                    </div>
-                </div>
-
-                <!-- Toolbar: Sort -->
-
-                <div class="form-group sort">
-                    <div class="dropdown btn-group">
-                        <button type="button"
-                                class="btn btn-default dropdown-toggle"
-                                data-toggle="dropdown"
-                                aria-haspopup="true"
-                                aria-expanded="false">Name <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu">
-                            <li><a href="#">Name</a></li>
-                            <li><a href="#">Type</a></li>
-                        </ul>
-                    </div>
-                    <button class="btn btn-link" type="button">
-                        <span class="fa fa-sort-alpha-asc"></span>
-                    </button>
-                </div>
-                <div class="toolbar-pf-action-right">
-                    <button type="button"
-                            class="btn btn-primary dropdown-toggle"
-                            [routerLink]="['create']">Create
-                    </button>
-                </div>
+  
+  <!-- Toolbar -->
+  
+  <div class="row toolbar-pf">
+    <div class="col-sm-12">
+      <div class="toolbar-pf-actions">
+        
+        <!-- Toolbar: Search -->
+        
+        <div class="form-group toolbar-pf-filter search">
+          <label class="sr-only">Name</label>
+          <div class="input-group">
+            <div class="input-group-btn">
+              <button type="button"
+                      class="btn btn-default dropdown-toggle"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false">Name&nbsp;<span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li><a href="#">Name</a></li>
+                <li><a href="#">Type</a></li>
+              </ul>
             </div>
-        </div><!-- /col -->
-    </div><!-- /row -->
-
-
-    <div class="container-cards-pf">
-        <div class="row row-cards-pf">
-
-            <!-- Connection Card -->
-
-            <div class="col-xs-12 col-sm-3 col-md-2 card"
-                 *ngFor="let connection of connections | connectionFilter: listFilter | orderBy : ['name', 'type']">
-                 <div class="card-pf card-pf-view card-pf-view-xs">
-                    <div class="card-pf-body">
-
-                        <!-- Card Dropdown -->
-
-                        <div class="card-pf-heading-kebab">
-                            <div class="dropdown pull-right dropdown-kebab-pf card-pf-time-frame-filter">
-                              <button type="button"
-                                        class="btn btn-link dropdown-toggle"
-                                        data-toggle="dropdown">
-                                    <span class="fa fa-ellipsis-v"></span>
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-right"
-                                    role="menu">
-                                    <li>
-                                    <a [routerLink]="['detail', connection.name.toLowerCase()]">Edit</a>
-                                    </li>
-                                    <li>
-                                        <a (click)="duplicateConnection(connection, $event)">Duplicate</a>
-                                    </li>
-                                    <li>
-                                        <a (click)="deleteConnection(connection, $event)">Delete</a>
-                                    </li>
-                                </ul>
-                            </div>
-
-                            <!-- Card Title & Icon -->
-
-                            <h2 class="card-pf-title">
-                                <span class="fa {{ connection.icon }}"></span>
-                            </h2>
-                            <div (click)="gotoDetail(connection, $event)" class="card-title">{{ connection.name | truncate:'12':'' }}</div>
-                        </div>
-
-                        <!-- Card Description -->
-
-                        <p (click)="gotoDetail(connection, $event)">
-                            {{ connection.description | truncate:limit:trail }}
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="error"
-                 *ngIf="errorMessage">{{errorMessage}}</div>
+            <input type="text"
+                   class="form-control"
+                   placeholder="Filter By Name..."
+                   autocomplete="off"
+                   [(ngModel)]="listFilter"
+                   id="filterInput">
+          </div>
         </div>
+        
+        <!-- Toolbar: Sort -->
+        
+        <div class="form-group sort">
+          <div class="dropdown btn-group">
+            <button type="button"
+                    class="btn btn-default dropdown-toggle"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false">Name&nbsp;<span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="#">Name</a></li>
+              <li><a href="#">Type</a></li>
+            </ul>
+          </div>
+          <button class="btn btn-link"
+                  type="button">
+            <span class="fa fa-sort-alpha-asc"></span>
+          </button>
+        </div>
+        <div class="toolbar-pf-action-right">
+          <button type="button"
+                  class="btn btn-primary dropdown-toggle"
+                  [routerLink]="['create']">Create
+          </button>
+        </div>
+      </div>
+    </div><!-- /col -->
+  </div><!-- /row -->
+  
+  
+  <div class="container-cards-pf">
+    <div class="row row-cards-pf">
+      
+      <!-- Connection Card -->
+      
+      <div class="col-xs-12 col-sm-3 col-md-2 card"
+           *ngFor="let connection of connections | connectionFilter: listFilter | orderBy : ['name', 'type']">
+        <div class="card-pf card-pf-view card-pf-view-xs">
+          <div class="card-pf-body">
+            
+            <!-- Card Dropdown -->
+            
+            <div class="card-pf-heading-kebab">
+              <div class="dropdown pull-right dropdown-kebab-pf card-pf-time-frame-filter">
+                <button type="button"
+                        class="btn btn-link dropdown-toggle"
+                        data-toggle="dropdown">
+                  <span class="fa fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right"
+                    role="menu">
+                  <li>
+                    <a [routerLink]="['detail', connection.name.toLowerCase()]">Edit</a>
+                  </li>
+                  <li>
+                    <a (click)="duplicateConnection(connection, $event)">Duplicate</a>
+                  </li>
+                  <li>
+                    <a (click)="deleteConnection(connection, $event)">Delete</a>
+                  </li>
+                </ul>
+              </div>
+              
+              <!-- Card Title & Icon -->
+              
+              <h2 class="card-pf-title">
+                <span class="fa {{ connection.icon }}"></span>
+              </h2>
+              <div (click)="gotoDetail(connection, $event)"
+                   class="card-title">{{ connection.name | truncate:'12':'' }}
+              </div>
+            </div>
+            
+            <!-- Card Description -->
+            
+            <p (click)="gotoDetail(connection, $event)">
+              {{ connection.description | truncate:limit:trail }} </p>
+          </div>
+        </div>
+      </div>
+      
+      <div class="error"
+           *ngIf="errorMessage">{{errorMessage}}
+      </div>
     </div>
+  </div>
+  
+  <script>
+    (function($) {
+      $(document).ready(function() {
+        // Upon clicking the find button, show the find dropdown content
+        $(".btn-find").click(function() {
+          $(".find-pf-dropdown-container").toggle();
+        });
+        // Upon clicking the find close button, hide the find dropdown content
+        $(".btn-find-close").click(function() {
+          $(".find-pf-dropdown-container").hide();
+        });
 
-    <script>
-        (function($) {
-            $(document).ready(function() {
-                // Upon clicking the find button, show the find dropdown content
-                $(".btn-find").click(function() {
-                    $(".find-pf-dropdown-container").toggle();
-                });
-                // Upon clicking the find close button, hide the find dropdown content
-                $(".btn-find-close").click(function() {
-                    $(".find-pf-dropdown-container").hide();
-                });
-
-            });
-        })(jQuery);
-    </script>
+      });
+    })(jQuery);
+  </script>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,34 +13,34 @@ let log = Logger.get('App');
  * Top Level Component
  */
 @Component({
-    selector: 'app',
-    encapsulation: ViewEncapsulation.None,
-    styles: [ require('../assets/scss/main.scss') ],
-    templateUrl: './index.html'
+  selector: 'app',
+  encapsulation: ViewEncapsulation.None,
+  styles: [ require('../assets/scss/main.scss') ],
+  templateUrl: './index.html'
 })
 export class App {
-    name = 'Red Hat iPaaS';
 
-    // White BG
-    logoWhiteBg = 'assets/images/rh_ipaas_small.svg';
-    iconWhiteBg = 'assets/images/glasses_logo.svg';
+  private iconDarkBg: string;
+  private iconWhiteBg: string;
+  private logoDarkBg: string;
+  private logoWhiteBg: string;
+  private twitterUrl: string;
+  private loggedIn = true;
+  //private loggedIn = false;
+  private title: string;
 
-    // Dark BG
-    logoDarkBg = 'assets/images/rh_ipaas_small.svg';
-    iconDarkBg = 'assets/images/glasses_logo.svg';
+  /**
+   * Constructor.
+   * @param _appState -- AppState
+   */
+  constructor(private _appState: AppState) {
+    this.iconDarkBg = _appState.state.iconDarkBg;
+    this.logoDarkBg = _appState.state.logoDarkBg;
+    this.title = _appState.state.title;
+  }
 
-    title = 'Red Hat iPaaS';
-    url = 'https://www.twitter.com/jboss';
-    loggedIn = true;
-    //loggedIn = false;
-
-    /**
-     * Constructor.
-     */
-    constructor(public appState: AppState) {}
-
-    ngOnInit() {
-        log.debug('Initial App State', this.appState);
-    }
+  ngOnInit() {
+    log.debug('Initial App State', this._appState);
+  }
 
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,6 +37,7 @@ export class App {
     this.iconDarkBg = _appState.state.iconDarkBg;
     this.logoDarkBg = _appState.state.logoDarkBg;
     this.title = _appState.state.title;
+    this.twitterUrl = _appState.state.twitterUrl;
   }
 
   ngOnInit() {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,10 @@
 export const Globals = Object.freeze({
   apiEndpoint: 'http://localhost:8080/v1',
-  title: 'Red Hat iPaaS'
+  iconDarkBg: '../assets/images/glasses_logo.svg',
+  iconWhiteBg: '../assets/images/glasses_logo.svg',
+  logoDarkBg: '../assets/images/rh_ipaas_small.svg',
+  logoWhiteBg: '../assets/images/rh_ipaas_small.svg',
+  title: 'Red Hat iPaaS',
+  twitterUrl: 'https://www.twitter.com/jboss'
 });
 

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -30,14 +30,17 @@ export class AppState {
   }
 
   // Used to load settings from the server, returns a promise so angular waits
-  // during bootstrap.  Log is passed in here to help avoid circular dependencies
+  // during bootstrap. Log is passed in here to help avoid circular dependencies
   load(): Promise<AppState> {
-    var promise = this.http.get(configJson).map(res => res.json()).toPromise();
+    let promise = this.http.get(configJson).map(res => res.json()).toPromise();
+
     promise.then((config) => {
-      log.debug('Using configuration: ', config);
+      //log.debug('Using configuration: ', config);
       this._state = _.merge({}, this._state, config);
+
       return this;
     });
+
     return promise;
   }
 
@@ -54,13 +57,17 @@ export class AppState {
   get(prop: string, resetFromStorage?: boolean): any {
     // use our state getter for the clone
     const state = this.state;
+
     if (resetFromStorage) {
       this.set(prop, undefined);
     }
-    var answer: any = _.get(state, prop);
+
+    let answer: any = _.get(state, prop);
+
     if (!answer) {
       // check local storage
       answer = localStorage.getItem(prop);
+
       if (answer && _.startsWith(answer, '{') || _.startsWith(answer, '[')) {
         try {
           answer = JSON.parse(answer);
@@ -68,13 +75,16 @@ export class AppState {
           // we'll just return answer as a string
         }
       }
+
       this.set(prop, answer);
     }
+
     return answer;
   }
 
   clear(prop: string, persist?: boolean): any {
     _.set(this._state, prop, undefined);
+
     if (persist) {
       localStorage.removeItem(prop);
     }
@@ -82,14 +92,18 @@ export class AppState {
 
   set(prop: string, value: any, persist?: boolean): any {
     let val = value;
+
     // internally mutate our state
     _.set(this._state, prop, value);
+
     if (persist) {
       if (!_.isString(value)) {
         value = JSON.stringify(value);
       }
+
       localStorage.setItem(prop, value);
     }
+
     return val;
   }
 

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -20,8 +20,8 @@ describe('App', () => {
         ]
     }));
 
-    it('should have a url', inject([ App ], (app) => {
-        expect(app.url).toEqual('https://www.twitter.com/jboss');
+    it('should have a Twitter url', inject([ App ], (app) => {
+        expect(app.twitterUrl).toEqual('https://www.twitter.com/jboss');
     }));
 
 });

--- a/src/app/common/service/log.ts
+++ b/src/app/common/service/log.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 
-import { AppState } from './../../app.service';
+import { AppState } from '../../app.service';
 
-export var Logger:any = require('js-logger');
+export let Logger:any = require('js-logger');
 
 Logger.useDefaults();
 

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -22,14 +22,6 @@
             </button>
             <a [routerLink]=" ['/'] "
                class="navbar-brand">
-                <!--
-                <img class="navbar-brand-icon"
-                     src="/assets/images/logo-alt.svg"
-                     alt=""/>
-                <img class="navbar-brand-name"
-                     src="/assets/images/brand-alt.svg"
-                     alt="iPaaS" />
-                     -->
                 <img class="navbar-brand-icon"
                      [src]="iconDarkBg"
                      alt=""/>

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -6,6 +6,10 @@ html {
   }
 }
 
+.breadcrumb {
+  margin-bottom: 0;
+}
+
 .center {
   margin: 0 auto;
 }


### PR DESCRIPTION
# Overview
Not a ton of functionality in this PR but some key things for the demo.

- Aesthetic changes to reflect designs better across Connections user flow
- Update connection details to pull proper data (ie added breadcrumbs)
- Removed state management for now (buggy)
- Fixed minor bug where check for value is necessary before calling a split method
- Updated Connection model to reflect actual data
- Lots of cleanup, better logging

## Screenshots

### Aesthetic Changes

<img width="1440" alt="screenshot 2016-12-22 12 51 07" src="https://cloud.githubusercontent.com/assets/3844502/21435208/7b7dc28e-c846-11e6-9d8a-de7f6313a47b.png">

### Disable State Management
This allows the Create Connection work flow to work again.

<img width="568" alt="screenshot 2016-12-22 12 51 21" src="https://cloud.githubusercontent.com/assets/3844502/21435211/7e7098c2-c846-11e6-97b0-f539bea5d970.png">

### Connection Details w/ API Data & Aesthetic Improvements

<img width="1440" alt="screenshot 2016-12-22 12 59 10" src="https://cloud.githubusercontent.com/assets/3844502/21435214/8177d058-c846-11e6-8372-ada144657ab1.png">


cc @jimmidyson 