### PR TITLE
Ensure loading spinner is in consistent position across lists

### DIFF
--- a/src/app/common/loading/loading.component.html
+++ b/src/app/common/loading/loading.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="loading">
+<div class="loading" *ngIf="loading">
   <div class="spinner spinner-lg"></div>
 </div>
 <ng-content *ngIf="!loading"></ng-content>

--- a/src/app/common/loading/loading.component.scss
+++ b/src/app/common/loading/loading.component.scss
@@ -1,0 +1,3 @@
+.loading {
+  padding-top: 20px;
+}

--- a/src/app/connections/list/list.component.html
+++ b/src/app/connections/list/list.component.html
@@ -1,7 +1,6 @@
-<div class="container-cards-pf">
-  <div class="row row-cards-pf">
-
-    <ipaas-loading [loading]="loading">
+<ipaas-loading [loading]="loading">
+  <div class="container-cards-pf">
+    <div class="row row-cards-pf">
       <div class="col-xs-12 col-sm-3 col-md-2 card" *ngFor="let connection of connections">
         <div class="card-pf card-pf-view card-pf-view-xs">
           <div class="card-pf-body">
@@ -43,6 +42,6 @@
           </div>
         </div>
       </div>
-    </ipaas-loading>
+    </div>
   </div>
-</div>
+</ipaas-loading>

--- a/src/app/integrations/list/list.component.html
+++ b/src/app/integrations/list/list.component.html
@@ -1,6 +1,5 @@
-<div class='list-group list-view-pf list-view-pf-view'>
-
-  <ipaas-loading [loading]="loading">
+<ipaas-loading [loading]="loading">
+  <div class='list-group list-view-pf list-view-pf-view'>
     <div class='list-group-item integration' *ngFor='let integration of integrations'>
       <div class='list-view-pf-checkbox'>
         <input type='checkbox'>
@@ -48,5 +47,5 @@
         </div>
       </div>
     </div>
-  </ipaas-loading>
-</div>
+  </div>
+</ipaas-loading>

--- a/src/app/templates/list/list.component.html
+++ b/src/app/templates/list/list.component.html
@@ -1,7 +1,6 @@
-<div class="container-cards-pf">
-  <div class="row row-cards-pf">
-
-    <ipaas-loading [loading]="loading">
+<ipaas-loading [loading]="loading">
+  <div class="container-cards-pf">
+    <div class="row row-cards-pf">
       <div class="col-xs-12 col-sm-3 col-md-2 card" *ngFor="let template of templates">
         <div class="card-pf card-pf-view card-pf-view-xs">
           <div class="card-pf-body">
@@ -47,6 +46,6 @@
           </div>
         </div>
       </div>
-    </ipaas-loading>
+    </div>
   </div>
-</div>
+</ipaas-loading>


### PR DESCRIPTION
Because integrations list is a slightly different view (why btw)? The loader wasn't consistent with other list views.

It's subtle, but it's there - you have to look closely in these gifs to see it, have to figure out a better way to highlight changes like this without being too onerous.

Here's a before:

![before](https://cloud.githubusercontent.com/assets/464659/21845967/adc13914-d7ec-11e6-93ec-c757f3cd15d2.gif)

And an after:

![after](https://cloud.githubusercontent.com/assets/464659/21845976/b23a6e48-d7ec-11e6-8343-b5ab6668f955.gif)